### PR TITLE
Successfully compile with Crystal-v0.22.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-/doc/
+/.deps/
+/lib/
 /libs/
+/doc/
 /.crystal/
 /.shards/
 

--- a/src/shell.cr
+++ b/src/shell.cr
@@ -1,8 +1,8 @@
 class Shell
 
   def initialize(@cmd : String,
-                 @stdout : Stdio = MemoryIO.new,
-                 @stderr : Stdio = MemoryIO.new,
+                 @stdout : Process::Stdio = IO::Memory.new,
+                 @stderr : Process::Stdio = IO::Memory.new,
                  @fail_on_error : Bool = true
                 )
     @status = 0


### PR DESCRIPTION
In Crystal-v0.20.4, MemoryIO was removed, so I change the code to use IO::Memory.